### PR TITLE
Add middleware for background jobs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    servicelog (0.1.0)
+    servicelog (0.2.0)
       rails (>= 5.0.0)
       request_store (>= 1.4.0)
 
@@ -84,7 +84,7 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
-    loofah (2.5.0)
+    loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -106,7 +106,7 @@ GEM
     parallel (1.19.1)
     parser (2.7.1.2)
       ast (~> 2.4.0)
-    rack (2.2.2)
+    rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.3)
@@ -161,9 +161,9 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
-    websocket-driver (0.7.1)
+    websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.4)
+    websocket-extensions (0.1.5)
     zeitwerk (2.3.0)
 
 PLATFORMS

--- a/lib/servicelog.rb
+++ b/lib/servicelog.rb
@@ -5,6 +5,7 @@ require 'servicelog/configuration'
 require 'generators/servicelog/install_generator'
 require 'servicelog/railtie'
 require 'servicelog/middlewares/store_headers'
+require 'servicelog/middlewares/shoryuken_store_headers'
 require 'servicelog/middlewares/request_id'
 
 module Servicelog

--- a/lib/servicelog/middlewares/shoryuken_store_headers.rb
+++ b/lib/servicelog/middlewares/shoryuken_store_headers.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'request_store'
+
+module Servicelog
+  class ShoryukenStoreHeaders
+    def initialize(app = nil)
+      @app = app
+    end
+
+    def call(_worker_instance, _queue, sqs_msg, body)
+      set_request_id(sqs_msg, body)
+      yield
+    end
+
+    private
+
+    def set_request_id(sqs_msg, body)
+      return if sqs_msg.nil? && body.nil?
+
+      Servicelog.headers['X-Request-Id'] ||= body['job_id'] || sqs_msg.message_id
+    end
+  end
+end

--- a/lib/servicelog/version.rb
+++ b/lib/servicelog/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Servicelog
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
**Vault PR:** https://github.com/volcanic-uk/vault/pull/623
**Krakatoa PR:** https://github.com/volcanic-uk/krakatoa/pull/1781
**Xenolith PR:** https://github.com/volcanic-uk/xenolith/pull/361

Add a new middleware to be used by v10 services: KK, Vault, Xenolith...

Once this updated gem is used by Krakatoa, Xenolith or Vault and the middleware is registered to **Shoryuken**, the middleware graps the job ID and adds it to the header `X-Request-Id`

Gem version updated from `0.1.0` to `0.2.0` (added functionality in a backwards compatible manner)