### PR TITLE
Ensure base classes are required before monkeypatching them

### DIFF
--- a/lib/servicelog/adapters/activeresource.rb
+++ b/lib/servicelog/adapters/activeresource.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# Ensure that the base code has been loaded before monkeypatching
+# If it isn't loaded first, it will overwrite this monkeypatch
+require 'activeresource'
+
 module ActiveResource
   class Connection
     alias original_build_request_headers build_request_headers

--- a/lib/servicelog/adapters/httparty.rb
+++ b/lib/servicelog/adapters/httparty.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# Ensure that the base code has been loaded before monkeypatching
+# If it isn't loaded first, it will overwrite this monkeypatch
+require 'httparty'
+
 module HTTParty
   module ClassMethods
     alias original_headers headers


### PR DESCRIPTION
When using adapters, if the monkeypatch is applied before the apdated
class, the original implementation will be used. To prevent that from
happening, require the base class before applying the monkeypatch.